### PR TITLE
fix: prevent icons from floating to right

### DIFF
--- a/packages/q3-admin/src/components/Viewport/Viewport.jsx
+++ b/packages/q3-admin/src/components/Viewport/Viewport.jsx
@@ -35,7 +35,7 @@ const AppViewport = ({ children }) => {
         backgroundColor: '#FFF',
         overflow: 'hidden',
         flexWrap: 'nowrap',
-        maxHeight,
+        position: 'relative',
       }}
     >
       <Grid container>{children}</Grid>


### PR DESCRIPTION
Added position: relative to the container since parent elements differ based on viewport