### PR TITLE
fix: s3 call with new axios instance

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,6 @@
-const withPackageOpts = (s) =>  `./packages/${s}/src` 
+const os = require('os');
+
+const withPackageOpts = (s) => `./packages/${s}/src`
 const withPackageTests = (s) => `./packages/${s}/tests`;
 
 const withTests = (s) => `${s}/tests`;
@@ -35,12 +37,18 @@ const alias = [
   'q3-ui-sse',
   'q3-ui-dropdownmenu',
 ].reduce(
-  (acc, curr) =>
-    Object.assign(acc, {
+  (acc, curr) => {
+    const exportDefinitions = {
       [withBundledDir(curr)]: withPackageOpts(curr),
       [withTests(curr)]: withPackageTests(curr),
-      // Removed default exports mapping to preserve workspace linking
-    }),
+    }
+
+    if (os.type() !== 'Darwin') {
+      exportDefinitions[curr] = withPackageOpts(curr);
+    }
+
+    return Object.assign(acc, exportDefinitions)
+  },
   {},
 );
 

--- a/packages/q3-ui-filemanager/src/useUploads/useUploads.js
+++ b/packages/q3-ui-filemanager/src/useUploads/useUploads.js
@@ -35,19 +35,19 @@ const useUploads = (collectionName, id) => {
         const compressed = await compressFile(file);
         const originalName = file.name;
         const { data: { url } } = await axios.post('/s3-upload', {
-          collectionName,
+          collection:collectionName,
           id,
-          mimeType: compressed.mimeType,
+          mimetype: compressed.type,
           name: originalName,
         })
 
         // note: this is to skip put request in our local integration tests
         if (url !== 'https://example.com/s3-upload') {
-          await axios.put(url, compressed)
+          await axios.create().put(url, compressed)
         }
 
         const { data: { uploads = [] } } = await axios.post('/s3-upload-transfer', {
-          collectionName,
+          collection: collectionName,
           id,
           name: folder
             ? `[${folder}]${originalName}`


### PR DESCRIPTION
Signed URLs fail because we have other authorization headers on the default axios instance.